### PR TITLE
Update test names to match unit test regex in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,12 @@ build:
 	  go build ./...
 
 .PHONY: test
-test: test-unit
+test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit:
 	  go test $(TESTS) -run 'Unit' -coverprofile=coverage.out
+
+.PHONY: test-integration
+test-integration:
+	  go test $(TESTS) -run 'Integration'

--- a/envconf_flag_test.go
+++ b/envconf_flag_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestFlagFromEnv(t *testing.T) {
+func TestIntegrationFlagFromEnv(t *testing.T) {
 	Convey("Replacing flags with env vars after parsing", t, func() {
 		os.Clearenv()
 

--- a/envconf_test.go
+++ b/envconf_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestFromEnv(t *testing.T) {
+func TestIntegrationFromEnv(t *testing.T) {
 	Convey("Value not replaced if environment variable not set", t, func() {
 		os.Clearenv()
 		v := interface{}("default")


### PR DESCRIPTION
Update the test names to contain "Integration" to match the regex in the Makefile.